### PR TITLE
mumps: build with scotch support

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "mpich-mumps",
   "mpich-parmetis",
   "mpich-scalapack"
 ]


### PR DESCRIPTION
- use core metis
- make parmetis mandatory when building with MPI
- make metis mandatory when building without MPI
- build with scotch
- remove option for scotch@5